### PR TITLE
Prevent opening Physics Bogie's UI with non empty hand

### DIFF
--- a/src/main/java/com/crystaelix/simurail/content/automatic_coupler/AutomaticCouplerBlock.java
+++ b/src/main/java/com/crystaelix/simurail/content/automatic_coupler/AutomaticCouplerBlock.java
@@ -196,6 +196,9 @@ public class AutomaticCouplerBlock extends HorizontalDirectionalBlock implements
 				return ItemInteractionResult.SUCCESS;
 			}
 		}
+		if(!stack.isEmpty()) {
+			return ItemInteractionResult.SKIP_DEFAULT_BLOCK_INTERACTION;
+		}
 		return ItemInteractionResult.PASS_TO_DEFAULT_BLOCK_INTERACTION;
 	}
 

--- a/src/main/java/com/crystaelix/simurail/content/bogey/PhysicsBogeyBlock.java
+++ b/src/main/java/com/crystaelix/simurail/content/bogey/PhysicsBogeyBlock.java
@@ -12,7 +12,9 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.RandomSource;
+import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
+import net.minecraft.world.ItemInteractionResult;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
@@ -137,6 +139,14 @@ public class PhysicsBogeyBlock extends HorizontalKineticBlock implements IBE<Phy
 			return new ItemStack(SimurailItems.INVERTED_PHYSICS_BOGEY.get());
 		}
 		return new ItemStack(this);
+	}
+
+	@Override
+	protected ItemInteractionResult useItemOn(ItemStack stack, BlockState state, Level level, BlockPos pos, Player player, InteractionHand hand, BlockHitResult hitResult) {
+		if(!stack.isEmpty()) {
+			return ItemInteractionResult.SKIP_DEFAULT_BLOCK_INTERACTION;
+		}
+		return ItemInteractionResult.PASS_TO_DEFAULT_BLOCK_INTERACTION;
 	}
 
 	@Override

--- a/src/main/java/com/crystaelix/simurail/content/gangway_frame/GangwayFrameBlock.java
+++ b/src/main/java/com/crystaelix/simurail/content/gangway_frame/GangwayFrameBlock.java
@@ -176,6 +176,9 @@ public class GangwayFrameBlock extends HorizontalDirectionalBlock implements IBE
 			level.playSound(null, pos, SoundEvents.DYE_USE, SoundSource.BLOCKS);
 			return ItemInteractionResult.SUCCESS;
 		}
+		if(!stack.isEmpty()) {
+			return ItemInteractionResult.SKIP_DEFAULT_BLOCK_INTERACTION;
+		}
 		return ItemInteractionResult.PASS_TO_DEFAULT_BLOCK_INTERACTION;
 	}
 


### PR DESCRIPTION
Fixes #56

`acd8bf2` moved the Physics Bogey's menu out of `useItemOn` (guarded by `stack.isEmpty()`) into `useWithoutItem`. Tho `useWithoutItem` also runs with an item in hand, and block interactions run before `ItemStack#useOn` so the blocks swallows the click.

Fixed it by making those 3 blcoks returning `SKIP_DEFAULT_BLOCK_INTERACTION`, for a non-empty hand (since the list of items concerned by the use case is non exhaustive) so it yields the click to the held item.