### PR TITLE
Run without compat dependency gradle property

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -186,6 +186,17 @@ loom {
 	}
 }
 
+// compat dependencies
+// -PwithoutMods=all, -PwithoutMods=electroenergetics,railways
+def compatMods = [
+	computercraft    : "cc.tweaked:cc-tweaked-1.21.1-forge:1.120.2",
+	electroenergetics: "curse.maven:create-electro-energetics-1443327:8345582",
+	create_bb        : "curse.maven:create-blocks-bogies-1317252:8723463",
+	railways         : "curse.maven:steam-n-rails-neoforge-1414670:8522154",
+]
+def withoutMods = (findProperty("withoutMods") ?: "").toString().split(",")*.trim() - ""
+def withoutMod = { id -> withoutMods.contains("all") || withoutMods.contains(id) }
+
 dependencies {
 	// Minecraft
 	minecraft "com.mojang:minecraft:1.21.1"
@@ -205,20 +216,26 @@ dependencies {
 	implementation "dev.ryanhcode.sable-companion:sable-companion-common-1.21.1:1.6.0"
 	implementation("dev.ryanhcode.sable:sable-neoforge-1.21.1:2.0.5") {transitive = false}
 	implementation("dev.simulated_team.simulated:simulated-neoforge-1.21.1:1.3.1") {transitive = false}
-	implementation "curse.maven:steam-n-rails-neoforge-1414670:8522154"
-	implementation "curse.maven:create-blocks-bogies-1317252:8723463"
 	implementation "curse.maven:create-coasters-simulated-1601871:8655742"
-	implementation "cc.tweaked:cc-tweaked-1.21.1-forge:1.120.2"
-	implementation "curse.maven:create-electro-energetics-1443327:8345582"
 	implementation("com.lowdragmc.ldlib2:ldlib2-neoforge-1.21.1:2.2.37:all") {transitive = false}
 	implementation "curse.maven:sable-schematic-tool-1526951:8606655"
 	implementation "curse.maven:synaxis-1526348:8606652"
+
+	// prevent compat from loading with -PwithoutMods=all.
+	compatMods.each { id, notation ->
+		compileOnly notation
+		if(!withoutMod(id)) {
+			runtimeOnly notation
+		}
+	}
 
 	// Testing
 	runtimeOnly("dev.eriksonn.aeronautics:aeronautics-neoforge-1.21.1:1.3.1") {transitive = false}
 	runtimeOnly("dev.ryanhcode.offroad:offroad-neoforge-1.21.1:1.3.1") {transitive = false}
 	runtimeOnly "thedarkcolour:kotlinforforge-neoforge:5.12.0"
-	runtimeOnly "com.lhwdev.minecraft:railx:0.2.0-build.14:mc1.21.1"
+	if(!withoutMod("railways")) { // railx is hard dependant on railways
+		runtimeOnly "com.lhwdev.minecraft:railx:0.2.0-build.14:mc1.21.1"
+	}
 	runtimeOnly("com.copycatsplus:copycats:3.0.8+mc.1.21.1-neoforge") {transitive = false}
 	runtimeOnly "com.rbasamoyai:ritchiesprojectilelib:2.1.2+mc.1.21.1-neoforge"
 	runtimeOnly("com.rbasamoyai:createbigcannons:5.11.7+mc.1.21.1") {transitive = false}


### PR DESCRIPTION
Add `-PwithoutMods` gradle command property.

Usage Examples:
* `gradle runClient -PwithoutMods=all` starts the client without any compat mod
* `gradle runClient -PwithoutMods=electroenergetics,railways` starts the client without CEE and SnR.

supports only mods with compat implementations.

Splits `implements` into `compileOnly` and `runtimeOnly`, and `runtimeOnly` is fed by the list filtered from the provided arguments of `withoutMods`.
