### PR TITLE
CurvedTrackSegment never initialized curveEnd.yOffsetPixels

### DIFF
--- a/src/main/java/com/crystaelix/simurail/content/track/CurvedTrackSegment.java
+++ b/src/main/java/com/crystaelix/simurail/content/track/CurvedTrackSegment.java
@@ -41,7 +41,7 @@ public final class CurvedTrackSegment extends TrackSegment {
 		curveStart = new TrackNodeLocation(curve.starts.getFirst()).in(dimension);
 		curveStart.yOffsetPixels = curve.yOffsetAt(curve.starts.getFirst());
 		curveEnd = new TrackNodeLocation(curve.starts.getSecond()).in(dimension);
-		curveStart.yOffsetPixels = curve.yOffsetAt(curve.starts.getSecond());
+		curveEnd.yOffsetPixels = curve.yOffsetAt(curve.starts.getSecond());
 	}
 
 	public BezierConnection curve() {


### PR DESCRIPTION
Fixes #69

`curveStart.yOffsetPixels` was initialized twice, and `curveEnd.yOffsetPixels` wasn't set, leading to first snap being off vertically. But once the bogey went backwards, the position was fixed.