### PR TITLE
fix: add invalidation of railx track updated curves

### DIFF
--- a/src/main/java/com/crystaelix/simurail/api/extension/BezierConnectionExtension.java
+++ b/src/main/java/com/crystaelix/simurail/api/extension/BezierConnectionExtension.java
@@ -7,4 +7,6 @@ public interface BezierConnectionExtension {
 	CubicBezier3dc simurail$controlPoints();
 
 	double simurail$quadratureLength();
+
+	void simurail$invalidateCurve();
 }

--- a/src/main/java/com/crystaelix/simurail/content/track/CurvedTrackSegment.java
+++ b/src/main/java/com/crystaelix/simurail/content/track/CurvedTrackSegment.java
@@ -29,11 +29,24 @@ public final class CurvedTrackSegment extends TrackSegment {
 		return segment / curve.getSegmentCount();
 	}
 
+	private static Vector3d curvePosition(BezierConnection curve, double t) {
+		return SimurailMath.position(curve, t, new Vector3d());
+	}
+
+	private static Vector3d curveNormal(BezierConnection curve, double t) {
+		Vector3d direction = SimurailMath.velocity(curve, t, new Vector3d());
+		Vector3d vertical = SimurailMath.slerp(
+				JOMLConversion.toJOML(curve.normals.getFirst()),
+				JOMLConversion.toJOML(curve.normals.getSecond()), t, new Vector3d());
+		Vector3d lateral = direction.cross(vertical, new Vector3d());
+		return lateral.cross(direction, vertical).normalize();
+	}
+
 	public CurvedTrackSegment(ResourceKey<Level> dimension, BezierConnection curve, int segment) {
 		super(dimension,
-				JOMLConversion.toJOML(curve.getPosition(segmentT(segment, curve))),
-				JOMLConversion.toJOML(curve.getPosition(segmentT(segment + 1, curve))),
-				JOMLConversion.toJOML(curve.getNormal(segmentT(segment + 0.5, curve))),
+				curvePosition(curve, segmentT(segment, curve)),
+				curvePosition(curve, segmentT(segment + 1, curve)),
+				curveNormal(curve, segmentT(segment + 0.5, curve)),
 				curve.getMaterial());
 		this.curve = curve;
 		this.segment = segment;

--- a/src/main/java/com/crystaelix/simurail/mixin/BezierConnectionMixin.java
+++ b/src/main/java/com/crystaelix/simurail/mixin/BezierConnectionMixin.java
@@ -1,5 +1,8 @@
 package com.crystaelix.simurail.mixin;
 
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -15,24 +18,39 @@ public abstract class BezierConnectionMixin implements BezierConnectionExtension
 	@Shadow
 	public abstract double getHandleLength();
 
+	@Shadow
+	@Final
+	private AtomicReference<Object> lazyRuntime;
+
 	@Unique
-	private CubicBezier3dc controlPoints;
+	private volatile CubicBezier3dc controlPoints;
 	@Unique
-	private double quadratureLength;
+	private volatile double quadratureLength;
 
 	@Override
 	public CubicBezier3dc simurail$controlPoints() {
-		if(controlPoints == null) {
-			controlPoints = SimurailMath.controlPoints(BezierConnection.class.cast(this));
+		CubicBezier3dc points = controlPoints;
+		if(points == null) {
+			points = SimurailMath.controlPoints(BezierConnection.class.cast(this));
+			controlPoints = points;
 		}
-		return controlPoints;
+		return points;
 	}
 
 	@Override
 	public double simurail$quadratureLength() {
-		if(quadratureLength == 0) {
-			quadratureLength = simurail$controlPoints().length(0, 1);
+		double length = quadratureLength;
+		if(length == 0) {
+			length = simurail$controlPoints().length(0, 1);
+			quadratureLength = length;
 		}
-		return quadratureLength;
+		return length;
+	}
+
+	@Override
+	public void simurail$invalidateCurve() {
+		lazyRuntime.set(null);
+		controlPoints = null;
+		quadratureLength = 0;
 	}
 }

--- a/src/main/java/com/crystaelix/simurail/mixin/SimurailMixinPlugin.java
+++ b/src/main/java/com/crystaelix/simurail/mixin/SimurailMixinPlugin.java
@@ -30,6 +30,9 @@ public class SimurailMixinPlugin implements IMixinConfigPlugin {
 			}
 			return isLoaded("railways");
 		}
+		if(mixinClassName.contains("compat.railx")) {
+			return isLoaded("railx");
+		}
 		return true;
 	}
 

--- a/src/main/java/com/crystaelix/simurail/mixin/TrackBlockEntityMixin.java
+++ b/src/main/java/com/crystaelix/simurail/mixin/TrackBlockEntityMixin.java
@@ -8,6 +8,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import com.crystaelix.simurail.api.extension.BezierConnectionExtension;
 import com.crystaelix.simurail.content.track.CurvedTrackSegmentCache;
 import com.llamalad7.mixinextras.sugar.Local;
 import com.simibubi.create.content.trains.track.BezierConnection;
@@ -40,12 +41,19 @@ public abstract class TrackBlockEntityMixin extends SmartBlockEntity {
 		}
 	}
 
-	@Inject(method = "addConnection", at = @At("TAIL"))
+
+	@Inject(method = "addConnection", at = @At("RETURN"))
 	public void simurail$onAddConnection(BezierConnection connection, CallbackInfo ci) {
-		if(!level.isClientSide()) {
-			CurvedTrackSegmentCache cache = CurvedTrackSegmentCache.getOrCreateCache(level.dimension());
-			cache.addCurve(connection);
+		if(level == null) {
+			return;
 		}
+		BezierConnection stored = connections.getOrDefault(connection.getKey(), connection);
+		((BezierConnectionExtension)stored).simurail$invalidateCurve();
+		if(level.isClientSide()) {
+			return;
+		}
+		CurvedTrackSegmentCache cache = CurvedTrackSegmentCache.getOrCreateCache(level.dimension());
+		cache.addCurve(stored);
 	}
 
 	@Inject(method = "removeConnection", at = @At("RETURN"))

--- a/src/main/java/com/crystaelix/simurail/mixin/compat/railx/BezierConnectionCompatMixin.java
+++ b/src/main/java/com/crystaelix/simurail/mixin/compat/railx/BezierConnectionCompatMixin.java
@@ -1,0 +1,21 @@
+package com.crystaelix.simurail.mixin.compat.railx;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.crystaelix.simurail.api.extension.BezierConnectionExtension;
+import com.simibubi.create.content.trains.track.BezierConnection;
+
+/**
+ * Railx edits the starts, axes and normals of live curves in place and announces every such edit through this method
+ */
+@Mixin(targets = "com.lhwdev.minecraft.railx.compat.BezierConnectionCompatKt", remap = false)
+public class BezierConnectionCompatMixin {
+
+	@Inject(method = "onCurveUpdated", at = @At("TAIL"))
+	private static void simurail$onCurveUpdated(BezierConnection curve, CallbackInfo ci) {
+		((BezierConnectionExtension)curve).simurail$invalidateCurve();
+	}
+}

--- a/src/main/resources/simurail.mixins.json
+++ b/src/main/resources/simurail.mixins.json
@@ -23,7 +23,8 @@
 
 		"compat.electroenergetics.AutomaticCouplerBlockMixin",
 		"compat.electroenergetics.PhysicsBogeyBlockMixin",
-		"compat.railways.TrackBufferBlockMixin"
+		"compat.railways.TrackBufferBlockMixin",
+		"compat.railx.BezierConnectionCompatMixin"
 	],
 	"injectors": {
 		"defaultRequire": 1


### PR DESCRIPTION
Fixes #71 


Simurail caches a curve's control points on the `BezierConnection` instance itself and never drops them. `starts`, `axes` and `normals` are mutable and railx edits them in place via the wrench-scroll rotation behaviour and via tilt smoothing. So after either of those the bogey keeps riding the shape the curve had before the edit.


`simurail$onAddConnection` is now injected at RETURN rather than TIAL. `addConnection` bails out early when the given curve already is the one mapped to its key, which is what happens whenever Create's tilt smoothing or railx edits a live curve in place and re-adds it. That curve still needs its cached shape dropped, so both exits have to be covered.

about `simurail$invalidateCurve`: the starts/axes of a curve are mutable and get edited in place by Create's and and railx's tilt smoothing. Create's own resolved shape is dropped alongside ours so the two can never end up describing different curves for the same connection. The chord of a track segment comes from one and its frame from the other.
