### PR TITLE
fix: anchor track segments on the primary curve

### DIFF
--- a/src/main/java/com/crystaelix/simurail/content/bogey/PhysicsBogeyAxle.java
+++ b/src/main/java/com/crystaelix/simurail/content/bogey/PhysicsBogeyAxle.java
@@ -512,9 +512,13 @@ public class PhysicsBogeyAxle {
 				double t = Math.clamp(trackSegment.projectT(trackAxleFrame.position), 0, 1);
 				if(trackSegment instanceof CurvedTrackSegment curve) {
 					BezierConnection connection = curve.curve();
-					double graphLength = connection.getLength();
+					// reverse edge measures its length along the secondary
+					double graphLength = trackEdge.getLength();
 					double quadratureLength = ((BezierConnectionExtension)connection).simurail$quadratureLength();
 					double quadraturePos = SimurailMath.length(connection, 0, curve.curveT(t));
+					if(curve.reversed()) {
+						quadraturePos = quadratureLength - quadraturePos;
+					}
 					trackPoint.position = graphLength / quadratureLength * quadraturePos;
 				}
 				else {

--- a/src/main/java/com/crystaelix/simurail/content/track/CurvedTrackSegment.java
+++ b/src/main/java/com/crystaelix/simurail/content/track/CurvedTrackSegment.java
@@ -16,11 +16,13 @@ import dev.ryanhcode.sable.companion.math.JOMLConversion;
 import net.createmod.catnip.data.Couple;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
 
 public final class CurvedTrackSegment extends TrackSegment {
 
 	final BezierConnection curve;
 	final int segment;
+	final boolean reversed;
 
 	final TrackNodeLocation curveStart;
 	final TrackNodeLocation curveEnd;
@@ -42,19 +44,46 @@ public final class CurvedTrackSegment extends TrackSegment {
 		return lateral.cross(direction, vertical).normalize();
 	}
 
-	public CurvedTrackSegment(ResourceKey<Level> dimension, BezierConnection curve, int segment) {
-		super(dimension,
-				curvePosition(curve, segmentT(segment, curve)),
-				curvePosition(curve, segmentT(segment + 1, curve)),
-				curveNormal(curve, segmentT(segment + 0.5, curve)),
-				curve.getMaterial());
-		this.curve = curve;
-		this.segment = segment;
+	// A curve's secondary resolves to a different shape than its primary, so always anchor on the primary
+	private record Form(BezierConnection curve, int segment, boolean reversed) {
 
-		curveStart = new TrackNodeLocation(curve.starts.getFirst()).in(dimension);
-		curveStart.yOffsetPixels = curve.yOffsetAt(curve.starts.getFirst());
-		curveEnd = new TrackNodeLocation(curve.starts.getSecond()).in(dimension);
-		curveEnd.yOffsetPixels = curve.yOffsetAt(curve.starts.getSecond());
+		static Form of(BezierConnection curve, int segment, boolean reversed) {
+			if(curve.isPrimary()) {
+				return new Form(curve, segment, reversed);
+			}
+			// Segment counts differ between the two, so remap through t
+			BezierConnection primary = curve.secondary();
+			int primaryCount = primary.getSegmentCount();
+			double t = 1 - (segment + 0.5) / curve.getSegmentCount();
+			int primarySegment = Math.clamp((int)(t * primaryCount), 0, Math.max(primaryCount - 1, 0));
+			return new Form(primary, primarySegment, !reversed);
+		}
+	}
+
+	public CurvedTrackSegment(ResourceKey<Level> dimension, BezierConnection curve, int segment) {
+		this(dimension, curve, segment, false);
+	}
+
+	public CurvedTrackSegment(ResourceKey<Level> dimension, BezierConnection curve, int segment, boolean reversed) {
+		this(dimension, Form.of(curve, segment, reversed));
+	}
+
+	private CurvedTrackSegment(ResourceKey<Level> dimension, Form form) {
+		super(dimension,
+				curvePosition(form.curve(), segmentT(form.reversed() ? form.segment() + 1 : form.segment(), form.curve())),
+				curvePosition(form.curve(), segmentT(form.reversed() ? form.segment() : form.segment() + 1, form.curve())),
+				curveNormal(form.curve(), segmentT(form.segment() + 0.5, form.curve())),
+				form.curve().getMaterial());
+		this.curve = form.curve();
+		this.segment = form.segment();
+		this.reversed = form.reversed();
+
+		Vec3 startEnd = reversed ? curve.starts.getSecond() : curve.starts.getFirst();
+		Vec3 endEnd = reversed ? curve.starts.getFirst() : curve.starts.getSecond();
+		curveStart = new TrackNodeLocation(startEnd).in(dimension);
+		curveStart.yOffsetPixels = curve.yOffsetAt(startEnd);
+		curveEnd = new TrackNodeLocation(endEnd).in(dimension);
+		curveEnd.yOffsetPixels = curve.yOffsetAt(endEnd);
 	}
 
 	public BezierConnection curve() {
@@ -65,14 +94,20 @@ public final class CurvedTrackSegment extends TrackSegment {
 		return segment;
 	}
 
+	public boolean reversed() {
+		return reversed;
+	}
+
 	public double curveT(double t) {
 		int iterations = 2;
-		return SimurailMath.segmentToCurveT(curve, segmentT(segment, curve), segmentT(segment + 1, curve), t, iterations);
+		return SimurailMath.segmentToCurveT(curve,
+				segmentT(segment, curve), segmentT(segment + 1, curve),
+				reversed ? 1 - t : t, iterations);
 	}
 
 	@Override
 	public CurvedTrackSegment reverse() {
-		return new CurvedTrackSegment(dimension, curve.secondary(), curve.getSegmentCount() - segment - 1);
+		return new CurvedTrackSegment(dimension, curve, segment, !reversed);
 	}
 
 	@Override
@@ -80,6 +115,9 @@ public final class CurvedTrackSegment extends TrackSegment {
 		double curveT = curveT(t);
 
 		SimurailMath.velocity(curve, curveT, dest.direction);
+		if(reversed) {
+			dest.direction.negate();
+		}
 
 		Vector3d normal1 = JOMLConversion.toJOML(curve.normals.getFirst());
 		Vector3d normal2 = JOMLConversion.toJOML(curve.normals.getSecond());
@@ -114,24 +152,30 @@ public final class CurvedTrackSegment extends TrackSegment {
 		TrackNode endNode = graph.locateNode(curveEnd);
 		if(startNode != null && endNode != null) {
 			TrackEdge edge = graph.getConnection(Couple.create(startNode, endNode));
-			if(edge != null && edge.isTurn() && BezierHashStrategy.INSTANCE.equals(curve, edge.getTurn())) {
-				return edge;
+			if(edge != null && edge.isTurn()) {
+				BezierConnection turn = edge.getTurn();
+				if(!turn.isPrimary()) {
+					turn = turn.secondary();
+				}
+				if(BezierHashStrategy.INSTANCE.equals(curve, turn)) {
+					return edge;
+				}
 			}
 		}
 		return null;
 	}
 
 	public CurvedTrackSegment next(boolean reverse) {
-		int nextSegment = segment + (reverse ? -1 : 1);
+		int nextSegment = segment + (reverse != reversed ? -1 : 1);
 		if(nextSegment < 0 || nextSegment >= curve.getSegmentCount()) {
 			return null;
 		}
-		return new CurvedTrackSegment(dimension, curve, nextSegment);
+		return new CurvedTrackSegment(dimension, curve, nextSegment, reversed);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(dimension, BezierHashStrategy.INSTANCE.hashCode(curve), segment);
+		return Objects.hash(dimension, BezierHashStrategy.INSTANCE.hashCode(curve), segment, reversed);
 	}
 
 	@Override
@@ -143,6 +187,7 @@ public final class CurvedTrackSegment extends TrackSegment {
 			return dimension.equals(other.dimension) &&
 					BezierHashStrategy.INSTANCE.equals(curve, other.curve) &&
 					segment == other.segment &&
+					reversed == other.reversed &&
 					material == other.material;
 		}
 		return false;

--- a/src/main/java/com/crystaelix/simurail/content/track/TrackSegment.java
+++ b/src/main/java/com/crystaelix/simurail/content/track/TrackSegment.java
@@ -179,6 +179,7 @@ public sealed abstract class TrackSegment permits StraightTrackSegment, CurvedTr
 			tag.putString("type", "curved");
 			tag.put("curve", curve.curve().write(BlockPos.ZERO));
 			tag.putInt("segment", curve.segment());
+			tag.putBoolean("reversed", curve.reversed());
 		}
 		}
 		tag.putString("dimension", dimension().location().toString());
@@ -202,7 +203,8 @@ public sealed abstract class TrackSegment permits StraightTrackSegment, CurvedTr
 		case "curved" -> {
 			BezierConnection curve = new BezierConnection(tag.getCompound("curve"), BlockPos.ZERO);
 			int segment = tag.getInt("segment");
-			return new CurvedTrackSegment(dimension, curve, segment);
+			boolean reversed = tag.getBoolean("reversed");
+			return new CurvedTrackSegment(dimension, curve, segment, reversed);
 		}
 		}
 		return null;


### PR DESCRIPTION
(finally) Fixes #67 


Create derives a curve's handle length from only one of the two values `VecHelper.intersect` returns, so a curve's `secondary()` is a different shape than its primary. On railx curves the two diverge by several blocks.

Only the primary is rendered, but `reverse()` swapped to `secondary()` and `fromTrackEdge` took whatever the edge held, so bogies could end up riding a shape nobody draws. Segments now always anchor on the primary and carry direction as a `reversed` flag instead.