### PR TITLE
Refactor build.gradle deps to better handle deps graph

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -186,16 +186,100 @@ loom {
 	}
 }
 
-// compat dependencies
-// -PwithoutMods=all, -PwithoutMods=electroenergetics,railways
-def compatMods = [
-	computercraft    : "cc.tweaked:cc-tweaked-1.21.1-forge:1.120.2",
-	electroenergetics: "curse.maven:create-electro-energetics-1443327:8345582",
-	create_bb        : "curse.maven:create-blocks-bogies-1317252:8723463",
-	railways         : "curse.maven:steam-n-rails-neoforge-1414670:8522154",
+// mod dependencies
+// Leave mods out with -PwithoutMods=all, -PwithoutMods=electroenergetics,railways
+//
+// ignorable true by default, whether the entry is affected by -PwithoutMods
+def core   = [configurations: "implementation", ignorable: false]
+def compat = [configurations: ["compileOnly", "runtimeOnly"]]
+def extra  = [configurations: "runtimeOnly"]
+def perfs = [configurations: "runtimeOnly", ignorable: false]
+def mods = [
+	// compiled against
+	jei                  	: core + [notation: "mezz.jei:jei-1.21.1-neoforge:19.44.0.405", transitive: false],
+	registrate           	: core + [notation: "com.tterrag.registrate:Registrate:MC1.21-1.3.0+67"],
+	flywheel             	: core + [notation: "dev.engine-room.flywheel:flywheel-neoforge-1.21.1:1.0.6-41"],
+	ponder               	: core + [notation: "net.createmod.ponder:ponder-neoforge:1.0.82+mc1.21.1"],
+	create               	: core + [notation: "com.simibubi.create:create-1.21.1:6.0.10-280:slim", transitive: false],
+	veil                 	: core + [notation: "foundry.veil:veil-neoforge-1.21.1:4.1.4", transitive: false],
+	sable_companion      	: core + [notation: "dev.ryanhcode.sable-companion:sable-companion-common-1.21.1:1.6.0"],
+	sable                	: core + [notation: "dev.ryanhcode.sable:sable-neoforge-1.21.1:2.0.5", transitive: false],
+	simulated            	: core + [notation: "dev.simulated_team.simulated:simulated-neoforge-1.21.1:1.3.1", transitive: false],
+
+	// compat
+	computercraft        	: compat + [notation: "cc.tweaked:cc-tweaked-1.21.1-forge:1.120.2"],
+	electroenergetics    	: compat + [notation: "curse.maven:create-electro-energetics-1443327:8345582"],
+	create_bb            	: compat + [notation: "curse.maven:create-blocks-bogies-1317252:8723463"],
+	railways             	: compat + [notation: "curse.maven:steam-n-rails-neoforge-1414670:8522154"],
+
+	// testing
+	aeronautics           	: extra + [notation: "dev.eriksonn.aeronautics:aeronautics-neoforge-1.21.1:1.3.1", transitive: false],
+	offroad               	: extra + [notation: "dev.ryanhcode.offroad:offroad-neoforge-1.21.1:1.3.1", transitive: false],
+	kotlinforforge        	: extra + [notation: "thedarkcolour:kotlinforforge-neoforge:5.12.0"],
+	copycats              	: extra + [notation: "com.copycatsplus:copycats:3.0.8+mc.1.21.1-neoforge", transitive: false],
+	ritchiesprojectilelib 	: extra + [notation: "com.rbasamoyai:ritchiesprojectilelib:2.1.2+mc.1.21.1-neoforge"],
+	createbigcannons      	: extra + [notation: "com.rbasamoyai:createbigcannons:5.11.7+mc.1.21.1", transitive: false],
+	transmission_linkage  	: extra + [notation: "curse.maven:create-aeronautics-transmission-linkage-1548056:8722967"],
+	drive_by_wire         	: extra + [notation: "curse.maven:drive-by-wire-with-sable-1520378:8247104"],
+	create_deco           	: extra + [notation: "curse.maven:create-deco-509285:7943181"],
+	aeronautics_toolgun   	: extra + [notation: "curse.maven:create-aeronauticstoolgun-1521349:8701394"],
+	railx                	: extra + [
+								notation : "com.lhwdev.minecraft:railx:0.2.0-build.14:mc1.21.1",
+								dependsOn: "railways",
+							],
+	create_coasters      	: extra + [notation: "curse.maven:create-coasters-simulated-1601871:8655742"],
+	ldlib2               	: extra + [notation: "com.lowdragmc.ldlib2:ldlib2-neoforge-1.21.1:2.2.37:all", transitive: false],
+	schematic_tool       	: extra + [
+								notation: "curse.maven:sable-schematic-tool-1526951:8606655",
+								dependsOn: "ldlib2"
+							],
+	synaxis              	: extra + [
+								notation: "curse.maven:synaxis-1526348:8606652",
+								dependsOn: ["ldlib2", "schematic_tool"]
+							],
+
+	// performance
+	yeetusexperimentus   	: perfs + [notation: "curse.maven:yeetusexperimentus-635427:5444189"],
+	modernfix            	: perfs + [notation: "curse.maven:modernfix-790626:8360807"],
+	ferritecore          	: perfs + [notation: "curse.maven:ferritecore-429235:7524151"],
 ]
 def withoutMods = (findProperty("withoutMods") ?: "").toString().split(",")*.trim() - ""
-def withoutMod = { id -> withoutMods.contains("all") || withoutMods.contains(id) }
+def asList = { value -> value == null ? [] : value instanceof Collection ? value.toList() : [value] }
+def dependsOnOf = { mod -> asList(mod.dependsOn) }
+def configurationsOf = { mod -> mod.configurations == null ? ["implementation"] : asList(mod.configurations) }
+
+// walk to remove dependants
+def keptMods = mods.findAll { id, mod -> !mod.getOrDefault("ignorable", true) }.keySet().toList()
+def keptMoreMods = true
+while(keptMoreMods) {
+	keptMoreMods = false
+	keptMods.toList().each { id ->
+		dependsOnOf(mods[id]).each { dep ->
+			if(mods.containsKey(dep) && !keptMods.contains(dep)) {
+				keptMods.add(dep)
+				keptMoreMods = true
+			}
+		}
+	}
+}
+
+def keptRequests = withoutMods.intersect(keptMods)
+if(!keptRequests.isEmpty()) {
+	logger.warn("mods: ${keptRequests.join(", ")} cannot be left out, keeping despite -PwithoutMods")
+}
+def disabledMods = (withoutMods.contains("all") ? mods.keySet().toList() : withoutMods.findAll { mods.containsKey(it) }) - keptMods
+
+def disabledMoreMods = true
+while(disabledMoreMods) {
+	disabledMoreMods = false
+	mods.each { id, mod ->
+		if(!disabledMods.contains(id) && !keptMods.contains(id) && dependsOnOf(mod).any { disabledMods.contains(it) }) {
+			disabledMods.add(id)
+			disabledMoreMods = true
+		}
+	}
+}
+def withoutMod = { id -> disabledMods.contains(id) }
 
 dependencies {
 	// Minecraft
@@ -206,48 +290,15 @@ dependencies {
 	}
 	neoForge "net.neoforged:neoforge:21.1.248"
 
-	// Dependencies
-	implementation("mezz.jei:jei-1.21.1-neoforge:19.44.0.405") {transitive = false}
-	implementation "com.tterrag.registrate:Registrate:MC1.21-1.3.0+67"
-	implementation "dev.engine-room.flywheel:flywheel-neoforge-1.21.1:1.0.6-41"
-	implementation "net.createmod.ponder:ponder-neoforge:1.0.82+mc1.21.1"
-	implementation("com.simibubi.create:create-1.21.1:6.0.10-280:slim") {transitive = false}
-	implementation("foundry.veil:veil-neoforge-1.21.1:4.1.4") {transitive = false}
-	implementation "dev.ryanhcode.sable-companion:sable-companion-common-1.21.1:1.6.0"
-	implementation("dev.ryanhcode.sable:sable-neoforge-1.21.1:2.0.5") {transitive = false}
-	implementation("dev.simulated_team.simulated:simulated-neoforge-1.21.1:1.3.1") {transitive = false}
-	implementation "curse.maven:create-coasters-simulated-1601871:8655742"
-	implementation("com.lowdragmc.ldlib2:ldlib2-neoforge-1.21.1:2.2.37:all") {transitive = false}
-	implementation "curse.maven:sable-schematic-tool-1526951:8606655"
-	implementation "curse.maven:synaxis-1526348:8606652"
-
-	// prevent compat from loading with -PwithoutMods=all.
-	compatMods.each { id, notation ->
-		compileOnly notation
-		if(!withoutMod(id)) {
-			runtimeOnly notation
+	// dynamicly load based on -PwithoutMods
+	mods.each { id, mod ->
+		def transitive = mod.getOrDefault("transitive", true)
+		configurationsOf(mod).each { configuration ->
+			if(configuration != "runtimeOnly" || !withoutMod(id)) {
+				add(configuration, mod.notation) {dep -> dep.transitive = transitive}
+			}
 		}
 	}
-
-	// Testing
-	runtimeOnly("dev.eriksonn.aeronautics:aeronautics-neoforge-1.21.1:1.3.1") {transitive = false}
-	runtimeOnly("dev.ryanhcode.offroad:offroad-neoforge-1.21.1:1.3.1") {transitive = false}
-	runtimeOnly "thedarkcolour:kotlinforforge-neoforge:5.12.0"
-	if(!withoutMod("railways")) { // railx is hard dependant on railways
-		runtimeOnly "com.lhwdev.minecraft:railx:0.2.0-build.14:mc1.21.1"
-	}
-	runtimeOnly("com.copycatsplus:copycats:3.0.8+mc.1.21.1-neoforge") {transitive = false}
-	runtimeOnly "com.rbasamoyai:ritchiesprojectilelib:2.1.2+mc.1.21.1-neoforge"
-	runtimeOnly("com.rbasamoyai:createbigcannons:5.11.7+mc.1.21.1") {transitive = false}
-	runtimeOnly "curse.maven:create-aeronautics-transmission-linkage-1548056:8722967"
-	runtimeOnly "curse.maven:drive-by-wire-with-sable-1520378:8247104"
-	runtimeOnly "curse.maven:create-deco-509285:7943181"
-	runtimeOnly "curse.maven:create-aeronauticstoolgun-1521349:8701394"
-
-	// Performance
-	runtimeOnly "curse.maven:yeetusexperimentus-635427:5444189"
-	runtimeOnly "curse.maven:modernfix-790626:8360807"
-	runtimeOnly "curse.maven:ferritecore-429235:7524151"
 }
 
 def replacements = [


### PR DESCRIPTION
Follow up of #65 

Refactor to not make it just functional, but actually handle the dependency graph to deactivate hard dependencies between the testing mods such that `-PwithoutMods` doesn't leads to a failed launch.

clearly separate the mods, moved sable-schematic-tool, ldlibsynaxis and create-coasters to testing (runtimeOnly).

Now testing mods can be removed via `-PwithoutMods`.

Also permits to have `transitive = false` deps/compat.