### PR TITLE
Physics Roller breaking two blocks height in front of itself

### DIFF
--- a/src/main/java/com/crystaelix/simurail/content/physics_roller/PhysicsRollerBlockEntity.java
+++ b/src/main/java/com/crystaelix/simurail/content/physics_roller/PhysicsRollerBlockEntity.java
@@ -58,7 +58,7 @@ import net.neoforged.neoforge.items.ItemHandlerHelper;
 public class PhysicsRollerBlockEntity extends SmartBlockEntity {
 
 	public static final Vec3 ACTIVE_AREA_OFFSET = new Vec3(0, -2, 0);
-	public static final double ACTIVE_AREA_REACH = 0.45;
+	public static final double ACTIVE_AREA_REACH = 0.95;
 
 	public static final double MAX_ROLL = Math.PI / 36;
 	public static final double MAX_PITCH = Math.PI / 4;

--- a/src/main/java/com/crystaelix/simurail/ponder/scenes/PhysicsRollerScenes.java
+++ b/src/main/java/com/crystaelix/simurail/ponder/scenes/PhysicsRollerScenes.java
@@ -53,7 +53,7 @@ public class PhysicsRollerScenes {
 
 		scene.title("physics_roller.intro", "header");
 		scene.configureBasePlate(0, 0, 15);
-		scene.scaleSceneView(0.5F);
+		scene.scaleSceneView(0.75F);
 		scene.addInstruction(new SceneRotationInstruction(180));
 		scene.showBasePlate();
 		scene.idle(10);
@@ -137,7 +137,7 @@ public class PhysicsRollerScenes {
 
 		scene.title("physics_roller.materials", "header");
 		scene.configureBasePlate(0, 0, 15);
-		scene.scaleSceneView(0.5F);
+		scene.scaleSceneView(0.75F);
 		scene.addInstruction(new SceneRotationInstruction(180));
 		scene.showBasePlate();
 		scene.idle(10);


### PR DESCRIPTION
increased ``ACTIVE_AREA_REACH``. Was at `0.45` to match create's rollers reach so that's not consistent reach anymore, but matches the two blocks height braking of the base roller. That's the tradeoff to get a similar match for the player. From feedback, the inconsistency seemed to bother ppl.

Also slightly adjusted the zoom level of the ponder to better fit on lower GUI scale setups.